### PR TITLE
Gscio: Use updated URL shortening API

### DIFF
--- a/src/Adapter/Gscio.php
+++ b/src/Adapter/Gscio.php
@@ -33,7 +33,7 @@ class Gscio extends AbstractAdapter
      */
     public function getApiUrl($url)
     {
-        return 'http://gsc.io/u/?rl=' . rawurlencode($url);
+        return 'http://u.gsc.io/?rl=' . rawurlencode($url);
     }
 
     /**


### PR DESCRIPTION
The API for the URL shortener is being relocated to u.gsc.io, from gsc.io/u. I'll keep the old gsc.io/u/... URLs working for a time to handle rolling out, though.